### PR TITLE
Require a virtualenv when using pip

### DIFF
--- a/etc/bashrc.bash
+++ b/etc/bashrc.bash
@@ -74,6 +74,7 @@ alias ll='ls -h -l'
 alias r='clear && ls -h -l'
 
 export PROJECTS="$HOME/projects" && mkdir -p "$PROJECTS"
+export PIP_REQUIRE_VIRTUALENV=true
 
 ############################################################################ CLI
 


### PR DESCRIPTION
This should probably be `pip`'s default behavior IMO.