### PR TITLE
Make master the default branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-    - gh-pages
+    - master
 sudo: required
 language: generic
 services:


### PR DESCRIPTION
This project doesn't explicitly need GitHub Pages (just a raw link would suffice for `deploy.sh`), but now it can be used with the master branch anyways.