### PR TITLE
Capitalize the Projects directory

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,7 @@
 sudo apt-get update;
 sudo apt-get install -y apt-listbugs apt-listchanges apt-transport-https;
 sudo apt-get upgrade && sudo dist-upgrade;
-[ "$PROJECTS" = '' ] && export PROJECTS="$HOME/projects";
+[ "$PROJECTS" = '' ] && export PROJECTS="$HOME/Projects";
 if [ ! -e "$PROJECTS" ]; then
     printf 'Creating a directory for projects... ';
     mkdir -p "$PROJECTS";

--- a/etc/bashrc.bash
+++ b/etc/bashrc.bash
@@ -73,7 +73,7 @@ alias grep='grep --color=auto'
 alias ll='ls -h -l'
 alias r='clear && ls -h -l'
 
-export PROJECTS="$HOME/projects" && mkdir -p "$PROJECTS"
+export PROJECTS="$HOME/Projects" && mkdir -p "$PROJECTS"
 export PIP_REQUIRE_VIRTUALENV=true
 
 ############################################################################ CLI


### PR DESCRIPTION
This will make it blend with other visible folders created by GNOME by default (e.g. Documents, Downloads, etc.).