### PR TITLE
Remove monitor in favor of watch(1)

### DIFF
--- a/etc/bashrc.bash
+++ b/etc/bashrc.bash
@@ -153,16 +153,6 @@ countdown () {
     for i in $(seq "${#prompt}"); do printf '\b \b'; done
 }
 
-monitor () {
-    # Continuously generate output.
-    while true
-    do
-        clear
-        $@
-        sleep 1
-    done
-}
-
 multiping () {
     for host in "$@"
     do


### PR DESCRIPTION
Resolves #47 

Use `watch` instead:

> watch - execute a program periodically, showing output fullscreen