### PR TITLE
Use a function instead of an alias for BSD tac

### DIFF
--- a/uninstall.bash
+++ b/uninstall.bash
@@ -17,6 +17,8 @@ config_home=
 # Since later things (e.g. `rm "$config_home/some.config"`)
 # may build on earlier things (e.g. `rmdir "$config_home"`),
 # the commands should be executed in reverse order to uninstall.
-command -v tac &>/dev/null || alias tac='tail -r'
+# shellcheck disable=SC2120
+command -v tac &>/dev/null || tac () { tail -r "$@"; }
+# shellcheck disable=SC2119
 tail -n "+$((LINENO + 2))" "${BASH_SOURCE[0]}" | tac | "$BASH" -o errexit -o pipefail -o xtrace 2>&1 | sed 's/^/  /'
 exit 0  # Do not execute commands that get appended.


### PR DESCRIPTION
On macOS,
```
uninstall.bash: line 21: tac: command not found
```