### PR TITLE
Prevent the lack of uptime from triggering the fail trap

### DIFF
--- a/config/bashrc.bash
+++ b/config/bashrc.bash
@@ -222,3 +222,4 @@ command -v uptime &>/dev/null && {
     else uptime
     fi
 }
+true


### PR DESCRIPTION
When starting a new shell without `uptime` available:
```
[Wed 10 Jul 2019 12:52:29 PM DST] 1
user@host:~ $ 
```