### PR TITLE
Remove --type usage from git.bash

### DIFF
--- a/deploy/git.bash
+++ b/deploy/git.bash
@@ -16,7 +16,7 @@ config_gitconfig="$config_home/gitconfig.ini"
 cp "$config_repo/config/$(basename "$config_gitconfig")" "$config_gitconfig"
 echo "rm '$config_gitconfig'" >> "$config_undo"
 git config --global --get include.path "$config_gitconfig" || {
-    git config --global --type path include.path "$config_gitconfig"
+    git config --global include.path "$config_gitconfig"
     echo "git config --global --unset include.path '$config_gitconfig'" >> "$config_undo"
 }
 echo 'Git configuration succeeded.'


### PR DESCRIPTION
Apparently `--type` is pretty new.