### PR TITLE
Correct bash target replacement on uninstall

### DIFF
--- a/install/bash.bash
+++ b/install/bash.bash
@@ -23,11 +23,8 @@ grep -q "$source_config" "$bashrc" || {
     echo "sed -i.old '\|$signature|d' '$bashrc'" >> "$config_undo"
     target='# dmtucker/config install target'
     if grep -q "$target" "$bashrc"
-    then
-        # shellcheck disable=SC2028
-        echo "sed -i.old '\|'$(printf '%q' "$source_config")'|s|$|\n$target|' '$bashrc'" >> "$config_undo"
-    else
-        echo "$target" >> "$bashrc"
+    then echo "sed -i.old 's|'$(printf '%q' "$source_config")'  $signature|$target|' '$bashrc'" >> "$config_undo"
+    else echo "$target" >> "$bashrc"
     fi
     sed -i.old "s|$target|$source_config  $signature|" "$bashrc"
 }


### PR DESCRIPTION
Followup to #104 